### PR TITLE
홈페이지 기능 개발 및 결과 화면 뷰 완료

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,7 +24,7 @@ body {
   display: flex;
   flex-direction: column;
   background-color: white;
-  background-image: url("./assets/bgBlur.svg");
+  background-image: url("@/assets/bgBlur.svg");
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;

--- a/src/components/home/MikeButton.tsx
+++ b/src/components/home/MikeButton.tsx
@@ -1,12 +1,32 @@
 import { ReactComponent as MicrophoneIcon } from "@/assets/microphone.svg";
+import { Link } from "react-router-dom";
 
-export default function MikeButton() {
-  return (
-    <div className="w-[251.62px] h-[249.23px] relative">
+interface MikeButtonProps {
+  isDisabled: boolean;
+}
+
+export default function MikeButton({ isDisabled }: MikeButtonProps) {
+  const buttonClass = isDisabled ? "opacity-50" : "cursor-pointer";
+
+  const buttonContent = (
+    <>
       <div className="w-[251.62px] h-[249.23px] left-0 top-0 absolute opacity-10 bg-indigo-300 rounded-full" />
       <div className="w-[221.43px] h-[219.32px] left-[15.10px] top-[14.95px] absolute opacity-40 bg-indigo-300 rounded-full" />
       <div className="w-[184.52px] h-[182.77px] left-[33.55px] top-[33.23px] absolute bg-purple-50 rounded-full shadow blur-[1px]" />
       <MicrophoneIcon className="w-[90px] h-[90px] left-[80.62px] top-[80.23px] absolute" />
+    </>
+  );
+
+  return isDisabled ? (
+    <div className={`w-[251.62px] h-[249.23px] relative ${buttonClass}`}>
+      {buttonContent}
     </div>
+  ) : (
+    <Link
+      to="/test"
+      className={`w-[251.62px] h-[249.23px] relative ${buttonClass}`}
+    >
+      {buttonContent}
+    </Link>
   );
 }

--- a/src/components/result/ResultBar.tsx
+++ b/src/components/result/ResultBar.tsx
@@ -1,0 +1,14 @@
+interface ResultBarProps {
+  children: string;
+}
+
+export default function ResultBar({ children }: ResultBarProps) {
+  return (
+    <div className="flex-column gap-[11px]">
+      <span>{children}</span>
+      <div className="w-full h-5 bg-blue-bg-bar rounded-[10px] flex-col justify-start items-start gap-2.5 inline-flex">
+        <div className="w-[133px] h-5 bg-blue-bar-2 rounded-[10px]"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,14 +2,17 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "@/App";
 import { BrowserRouter } from "react-router-dom";
+import { RecoilRoot } from "recoil";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <RecoilRoot>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </RecoilRoot>
   </React.StrictMode>
 );

--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -1,17 +1,41 @@
+import { useRecoilState } from "recoil";
+import { genderState } from "@/store/atom";
 import SelectButton from "@/components/common/SelectButton";
 import MikeButton from "@/components/home/MikeButton";
 
 export default function Home() {
+  const [gender, setGender] = useRecoilState(genderState);
+
+  const handleSelectGender = (selectedGender: string) => {
+    setGender((prevGender) =>
+      prevGender === selectedGender ? "" : selectedGender
+    );
+  };
+
   return (
     <div className="h-full items-center flex-column justify-evenly">
       <div className="flex-center flex-column gap-[15px]">
         <span className="text-black text-[14px]">성별을 선택해주세요.</span>
         <div className="flex gap-[25px]">
-          <SelectButton bgColor="bg-blue-base">남자</SelectButton>
-          <SelectButton bgColor="bg-blue-base">여자</SelectButton>
+          <SelectButton
+            onClick={() => handleSelectGender("남자")}
+            bgColor={`${
+              gender === "남자" ? "bg-blue-highlight" : "bg-blue-base"
+            }`}
+          >
+            남자
+          </SelectButton>
+          <SelectButton
+            onClick={() => handleSelectGender("여자")}
+            bgColor={`${
+              gender === "여자" ? "bg-blue-highlight" : "bg-blue-base"
+            }`}
+          >
+            여자
+          </SelectButton>
         </div>
       </div>
-      <MikeButton />
+      <MikeButton isDisabled={!gender} />
     </div>
   );
 }

--- a/src/page/Result.tsx
+++ b/src/page/Result.tsx
@@ -1,3 +1,48 @@
+import { Link, useLocation } from "react-router-dom";
+import { getPitchFromNote } from "@/audio/utils";
+import PitchButton from "@/components/common/PitchButton";
+import ResultButton from "@/components/common/ResultButton";
+
 export default function Result() {
-  return <div>측정 결과</div>;
+  const location = useLocation();
+  const highest = location.state.highest;
+  const lowest = location.state.lowest;
+
+  return (
+    <div className="flex-column flex-center">
+      <h2 className="text-[20px]">측정 결과</h2>
+      <div className="flex gap-[25px]">
+        <PitchButton
+          result={highest}
+          pitch={highest ? getPitchFromNote(highest).pitch : undefined}
+          kor={
+            highest
+              ? getPitchFromNote(highest).scale +
+                "옥타브 " +
+                getPitchFromNote(highest).korNoteString
+              : undefined
+          }
+        >
+          최고 음정
+        </PitchButton>
+        <PitchButton
+          result={lowest}
+          pitch={lowest ? getPitchFromNote(lowest).pitch : undefined}
+          kor={
+            lowest
+              ? getPitchFromNote(lowest).scale +
+                "옥타브 " +
+                getPitchFromNote(lowest).korNoteString
+              : undefined
+          }
+        >
+          최저 음정
+        </PitchButton>
+      </div>
+      <div></div>
+      <Link to={`/music?high=${highest}&low=${lowest}`}>
+        <ResultButton>노래 추천 받기</ResultButton>
+      </Link>
+    </div>
+  );
 }

--- a/src/page/Result.tsx
+++ b/src/page/Result.tsx
@@ -1,45 +1,57 @@
+import { useRecoilState } from "recoil";
+import { genderState } from "@/store/atom";
 import { Link, useLocation } from "react-router-dom";
 import { getPitchFromNote } from "@/audio/utils";
 import PitchButton from "@/components/common/PitchButton";
 import ResultButton from "@/components/common/ResultButton";
+import ResultBar from "@/components/result/ResultBar";
 
 export default function Result() {
+  const [gender, setGender] = useRecoilState(genderState);
+
   const location = useLocation();
   const highest = location.state.highest;
   const lowest = location.state.lowest;
 
   return (
-    <div className="flex-column flex-center">
-      <h2 className="text-[20px]">측정 결과</h2>
-      <div className="flex gap-[25px]">
-        <PitchButton
-          result={highest}
-          pitch={highest ? getPitchFromNote(highest).pitch : undefined}
-          kor={
-            highest
-              ? getPitchFromNote(highest).scale +
-                "옥타브 " +
-                getPitchFromNote(highest).korNoteString
-              : undefined
-          }
-        >
-          최고 음정
-        </PitchButton>
-        <PitchButton
-          result={lowest}
-          pitch={lowest ? getPitchFromNote(lowest).pitch : undefined}
-          kor={
-            lowest
-              ? getPitchFromNote(lowest).scale +
-                "옥타브 " +
-                getPitchFromNote(lowest).korNoteString
-              : undefined
-          }
-        >
-          최저 음정
-        </PitchButton>
+    <div className="flex-column items-center h-full justify-between">
+      <div className="flex-column items-center gap-[20px] pt-[25px]">
+        <h2 className="text-[20px]">측정 결과</h2>
+        <div className="flex gap-[25px]">
+          <PitchButton
+            result={highest}
+            pitch={highest ? getPitchFromNote(highest).pitch : undefined}
+            kor={
+              highest
+                ? getPitchFromNote(highest).scale +
+                  "옥타브 " +
+                  getPitchFromNote(highest).korNoteString
+                : undefined
+            }
+          >
+            최고 음정
+          </PitchButton>
+          <PitchButton
+            result={lowest}
+            pitch={lowest ? getPitchFromNote(lowest).pitch : undefined}
+            kor={
+              lowest
+                ? getPitchFromNote(lowest).scale +
+                  "옥타브 " +
+                  getPitchFromNote(lowest).korNoteString
+                : undefined
+            }
+          >
+            최저 음정
+          </PitchButton>
+        </div>
       </div>
-      <div></div>
+
+      <div className="flex-column gap-[40px] self-start w-full px-[15px]">
+        <ResultBar>{`${gender} 평균 음역대`}</ResultBar>
+        <ResultBar>내 음역대</ResultBar>
+      </div>
+
       <Link to={`/music?high=${highest}&low=${lowest}`}>
         <ResultButton>노래 추천 받기</ResultButton>
       </Link>

--- a/src/page/Test.tsx
+++ b/src/page/Test.tsx
@@ -117,7 +117,7 @@ export default function Test() {
         </div>
       ) : (
         <div className="flex-1 flex-center">
-          <Link to="/result">
+          <Link to="/result" state={{ highest, lowest }}>
             <ResultButton>측정 결과 확인하기</ResultButton>
           </Link>
         </div>

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const genderState = atom<string>({
+  key: "genderState",
+  default: undefined,
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,7 @@ module.exports = {
           pitch: "#A1A1FF", // 음성 듣기 및 포기하기
           "bar-1": "#D7D6FF", // 목표 음정 바
           "bar-2": "#A1C1FF", // 현재 음정 바,결과 음역대 범위 바
+          "bg-bar": "#C7D3EB",
           result: "#E1E1FA",
         },
       },


### PR DESCRIPTION
### 작업내용 및 전달사항

- 홈화면 기능 개발 완료 ~~(사실 뭐 기능이랄 것도 없지만)~~
  - recoil로 성별 전역 상태 설정
  - 성별 선택에 따른 스타일링 적용 및 상태 업데이트
- 결과화면 뷰 개발 완료
  - 기본적인 뷰는 완료했는데 평균 음역대나 내 음역대 범위 Bar로 나타내는 거는 구현 X
  - `src/components/result/ResultBar.tsx` 보면 색칠(?)되는 Bar 부분 width 임의의 값으로 설정해둔거 볼 수 있음! 이 부분 동적으로 수정 필요
- ❗모바일 반응형(특히 높이) 적용이 미흡해요 ㅠㅠ
  - 컴포넌트 사이에 px로 gap을 너무 많이 주면 화면 스크롤이 생기고...
  - 그거 막으려고 px 대신 justify-between과 같은 스타일링 속성 최대한 이용해봤지만 이렇게 되면 높이가 짧은 디바이스에서는 컴포넌트끼리 너무 붙어있음...
  - 제 방법이 잘못되었거나 개선할 방법이 있다면 의견 주세용